### PR TITLE
Update login procedure for ZTE H1600, handle login errors gracefully, add simple test program

### DIFF
--- a/ModemBot/cli.py
+++ b/ModemBot/cli.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import os
+import modem
+
+if __name__ == "__main__":
+    # TODO: Load config.toml, call getCPE() to get the modem instance
+    m = modem.ZTEh1600("192.168.1.1", "admin", os.getenv("PASSWORD"))
+
+    m.connect()
+    m.updateStats()
+    m.showStats()
+    m.disconnect()

--- a/ModemBot/modem.py
+++ b/ModemBot/modem.py
@@ -36,10 +36,13 @@ class Modem():
         raise NotImplementedError
     
     def showStats(self):
-        print(self.fecUP, self.fecDOWN)
-        print("ATTAINABLE UP %d ATTAINABLE DOWN %d" %(self.attainableUP, self.attainableDOWN))
-        print("SYNC UP: %d SYNC DOWN %d" % (self.syncUP, self.syncDOWN))
-        print("SNRS %f %f\nATT %f %f\nPOWER %f %f" % (self.snrUP, self.snrDOWN, self.attenuationUP, self.attenuationDOWN, self.powerUP, self.powerDOWN))
+        print("Attainable:  UP %-7d    DOWN %-7d" % (self.attainableUP, self.attainableDOWN))
+        print("Sync:        UP %-7d    DOWN %-7d" % (self.syncUP, self.syncDOWN))
+        print("SNR:         UP %-7.2f    DOWN %-7.2f" % (self.snrUP, self.snrDOWN))
+        print("Attenuation: UP %-7.2f    DOWN %-7.2f" % (self.attenuationUP, self.attenuationDOWN))
+        print("Power:       UP %-7.2f    DOWN %-7.2f" % (self.powerUP, self.powerDOWN))
+        print("CRC errors:  UP %-7d    DOWN %-7d" % (self.crcUP, self.crcDOWN))
+        print("FEC errors:  UP %-7d    DOWN %-7d" % (self.fecUP, self.fecDOWN))
     
     
 

--- a/ModemBot/modem.py
+++ b/ModemBot/modem.py
@@ -263,7 +263,11 @@ class ZTEh1600(ZTEModem):
             num = re.findall("\d+", xml)[0]
             #print(sessionToken, num)
             password = hashlib.sha256((self.PASSWORD+num).encode()).hexdigest()
-            authorizationData = {"action":"login","Username":self.USERNAME,"Password":password, "_sessionTOKEN":sessionToken}
+            authorizationData = {"action": "login",
+                                 "Username": self.USERNAME,
+                                 "Password": password,
+                                 "_sessionTOKEN": sessionToken,
+                                 "_sessionTOKENByPost": sessionToken}
             response = session.post(f"http://{self.HOST}/?_type=loginData&_tag=login_entry",data=authorizationData).content.decode()
             if json.loads(response)["login_need_refresh"] : 
                 session.get(f"http://{self.HOST}/")


### PR DESCRIPTION
Update the login procedure for ZTE H1600.
Handle login errors gracefully, include the error message as the modem returns it in `loginErrMsg`.
Add a simple CLI program to test the modem class directly.

Closes #3